### PR TITLE
🙈 Remove unnecessary `--` from `lint:fix` command

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -8,7 +8,7 @@
     "lint:sol": "solhint 'contracts/**/*.sol' && prettylint 'contracts/**/*.sol'",
     "lint:ts": "eslint '{test,scripts}/**/*.ts' -c .eslintrc.typescript.js --cache",
     "lint": "yarn run lint:sol && yarn run lint:ts",
-    "lint:fix": "prettier 'contracts/**/*.sol' --write --loglevel error && yarn run lint:ts -- --fix",
+    "lint:fix": "prettier 'contracts/**/*.sol' --write --loglevel error && yarn run lint:ts --fix",
     "build:sol": "waffle .waffle.json",
     "build:types": "typechain --target ethers-v5 --outDir build/types 'build/*.json' > /dev/null && echo 'Typechain generated'",
     "build:waffle": "yarn run clean && yarn run build:sol && yarn run build:types && bash ./scripts/indexBuild.sh",


### PR DESCRIPTION
Resolves warning: `warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.`
