### PR TITLE
➗ Divide raffle and auction bids according to contracts logic

### DIFF
--- a/packages/frontend/src/components/AllBids/AllBidsList.tsx
+++ b/packages/frontend/src/components/AllBids/AllBidsList.tsx
@@ -3,6 +3,7 @@ import { NothingFound } from 'src/components/AllBids/NothingFound'
 import { BidsListHeaders } from 'src/components/BidsList/BidsListHeaders'
 import { BidsSubList } from 'src/components/BidsList/BidsSubList'
 import { AUCTION_PARTICIPANTS_COUNT } from 'src/constants/auctionParticipantsCount'
+import { RAFFLE_PARTICIPANTS_COUNT } from 'src/constants/raffleParticipantsCount'
 import { useBids } from 'src/hooks/useBids'
 import { BidWithPlace } from 'src/models/Bid'
 
@@ -18,14 +19,19 @@ export const AllBidsList = ({ search }: AllBidsListProps) => {
     [search]
   )
 
+  const raffleBidsOffset = Math.max(0, bids.length - RAFFLE_PARTICIPANTS_COUNT)
+  const firstRaffleBidIndex =
+    raffleBidsOffset >= AUCTION_PARTICIPANTS_COUNT ? AUCTION_PARTICIPANTS_COUNT : raffleBidsOffset
+
   const auctionBids = useMemo(() => {
-    const sectionBids = bids.length <= AUCTION_PARTICIPANTS_COUNT ? bids : bids.slice(0, AUCTION_PARTICIPANTS_COUNT)
+    const sectionBids = bids.length <= RAFFLE_PARTICIPANTS_COUNT ? [] : bids.slice(0, firstRaffleBidIndex)
     return search ? searchBid(sectionBids) : sectionBids
-  }, [search, bids, searchBid])
+  }, [search, bids, searchBid, firstRaffleBidIndex])
   const raffleBids = useMemo(() => {
-    const sectionBids = bids.length <= AUCTION_PARTICIPANTS_COUNT ? [] : bids.slice(AUCTION_PARTICIPANTS_COUNT)
+    const sectionBids = bids.length > RAFFLE_PARTICIPANTS_COUNT ? bids.slice(firstRaffleBidIndex) : bids
     return search ? searchBid(sectionBids) : sectionBids
-  }, [search, bids, searchBid])
+  }, [search, bids, searchBid, firstRaffleBidIndex])
+
   const nothingFound = search && auctionBids.length === 0 && raffleBids.length === 0
 
   return (

--- a/packages/frontend/src/components/AllBids/AllBidsList.tsx
+++ b/packages/frontend/src/components/AllBids/AllBidsList.tsx
@@ -30,7 +30,7 @@ export const AllBidsList = ({ search }: AllBidsListProps) => {
   const raffleBids = useMemo(() => {
     const sectionBids = bids.length > RAFFLE_PARTICIPANTS_COUNT ? bids.slice(firstRaffleBidIndex) : bids
     return search ? searchBid(sectionBids) : sectionBids
-  }, [search, bids, searchBid, firstRaffleBidIndex])
+  }, [search, bids, searchBid]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const nothingFound = search && auctionBids.length === 0 && raffleBids.length === 0
 

--- a/packages/frontend/src/components/AllBids/AllBidsList.tsx
+++ b/packages/frontend/src/components/AllBids/AllBidsList.tsx
@@ -24,11 +24,11 @@ export const AllBidsList = ({ search }: AllBidsListProps) => {
     raffleBidsOffset >= AUCTION_PARTICIPANTS_COUNT ? AUCTION_PARTICIPANTS_COUNT : raffleBidsOffset
 
   const auctionBids = useMemo(() => {
-    const sectionBids = bids.length <= RAFFLE_PARTICIPANTS_COUNT ? [] : bids.slice(0, firstRaffleBidIndex)
+    const sectionBids = bids.slice(0, firstRaffleBidIndex)
     return search ? searchBid(sectionBids) : sectionBids
   }, [search, bids, searchBid, firstRaffleBidIndex])
   const raffleBids = useMemo(() => {
-    const sectionBids = bids.length > RAFFLE_PARTICIPANTS_COUNT ? bids.slice(firstRaffleBidIndex) : bids
+    const sectionBids = bids.slice(firstRaffleBidIndex)
     return search ? searchBid(sectionBids) : sectionBids
   }, [search, bids, searchBid]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/packages/frontend/src/components/AllBids/AllBidsList.tsx
+++ b/packages/frontend/src/components/AllBids/AllBidsList.tsx
@@ -26,7 +26,7 @@ export const AllBidsList = ({ search }: AllBidsListProps) => {
   const auctionBids = useMemo(() => {
     const sectionBids = bids.slice(0, firstRaffleBidIndex)
     return search ? searchBid(sectionBids) : sectionBids
-  }, [search, bids, searchBid, firstRaffleBidIndex])
+  }, [search, bids, searchBid]) // eslint-disable-line react-hooks/exhaustive-deps
   const raffleBids = useMemo(() => {
     const sectionBids = bids.slice(firstRaffleBidIndex)
     return search ? searchBid(sectionBids) : sectionBids

--- a/packages/frontend/src/constants/raffleParticipantsCount.ts
+++ b/packages/frontend/src/constants/raffleParticipantsCount.ts
@@ -1,0 +1,1 @@
+export const RAFFLE_PARTICIPANTS_COUNT = 80


### PR DESCRIPTION
Settings: `AUCTION_WINNERS: 10, RAFFLE_WINNERS: 40`
![localhost_3000_ (1)](https://user-images.githubusercontent.com/20744582/161966460-2023f465-d656-4c16-917e-66d1ebdada2b.png)

Settings: `AUCTION_WINNERS: 5, RAFFLE_WINNERS: 10`
![localhost_3000_](https://user-images.githubusercontent.com/20744582/161966405-a5e963eb-4e0d-4db3-8e28-f1fe0ef0b954.png)

Settings: `AUCTION_WINNERS: 5, RAFFLE_WINNERS: 19`
![localhost_3000_ (3)](https://user-images.githubusercontent.com/20744582/161966473-5fe3398d-24a6-4c24-8e8f-e873e55a23ec.png)
