### PR TITLE
❌ Exclude backend package from workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "update": "git submodule update --remote"
   },
   "workspaces": [
-    "packages/*"
+    "packages/contracts",
+    "packages/frontend"
   ],
   "devDependencies": {
     "wsrun": "^5.2.4"


### PR DESCRIPTION
Backend repo manages its own yarn.lock for now