### PR TITLE
Remove overflow from Form component

### DIFF
--- a/packages/frontend/src/components/Form/Form.tsx
+++ b/packages/frontend/src/components/Form/Form.tsx
@@ -7,7 +7,6 @@ export const Form = styled.div`
   row-gap: 16px;
   width: 100%;
   max-width: 460px;
-  overflow: hidden;
 `
 
 export const FormNarrow = styled(Form)`


### PR DESCRIPTION
This change allows for claiming deadline to show up in the component. 

![image](https://user-images.githubusercontent.com/20744582/163409812-ab94c527-bda2-4e16-8f7c-3f3030d41e36.png)
