### PR TITLE
🦨 Unpad zeroes from chainId passed to Metamask

### DIFF
--- a/packages/frontend/src/hooks/useSwitchChain.ts
+++ b/packages/frontend/src/hooks/useSwitchChain.ts
@@ -2,6 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { ChainId, useEthers } from '@usedapp/core'
 import { useCallback } from 'react'
+import { unpadHexString } from 'src/utils/formatters/unpadHexString'
 
 import { SupportedChainId } from '../constants/chainIDs'
 
@@ -28,7 +29,9 @@ const addArbitrumChain: AddEthereumChainParameter = {
   rpcUrls: ['https://arb1.arbitrum.io/rpc'],
   blockExplorerUrls: ['https://arbiscan.io'],
 }
-const getSwitchChainParam = (chainId: SupportedChainId): SwitchEthereumChainParameter => ({ chainId: toHex(chainId) })
+const getSwitchChainParam = (chainId: SupportedChainId): SwitchEthereumChainParameter => ({
+  chainId: unpadHexString(toHex(chainId)),
+})
 
 export function useSwitchChain() {
   const { library } = useEthers()

--- a/packages/frontend/src/hooks/useSwitchChain.ts
+++ b/packages/frontend/src/hooks/useSwitchChain.ts
@@ -19,7 +19,7 @@ interface SwitchEthereumChainParameter {
   chainId: string
 }
 
-const toHex = (value: number) => BigNumber.from(value).toHexString()
+const toHex = (value: number) => unpadHexString(BigNumber.from(value).toHexString())
 const arbitrumChainId = toHex(ChainId.Arbitrum)
 const errChainNotAddedYet = 4902
 
@@ -29,9 +29,7 @@ const addArbitrumChain: AddEthereumChainParameter = {
   rpcUrls: ['https://arb1.arbitrum.io/rpc'],
   blockExplorerUrls: ['https://arbiscan.io'],
 }
-const getSwitchChainParam = (chainId: SupportedChainId): SwitchEthereumChainParameter => ({
-  chainId: unpadHexString(toHex(chainId)),
-})
+const getSwitchChainParam = (chainId: SupportedChainId): SwitchEthereumChainParameter => ({ chainId: toHex(chainId) })
 
 export function useSwitchChain() {
   const { library } = useEthers()

--- a/packages/frontend/src/utils/formatters/unpadHexString.ts
+++ b/packages/frontend/src/utils/formatters/unpadHexString.ts
@@ -1,0 +1,1 @@
+export const unpadHexString = (hex: string) => hex.replace(/^0x0+/, '0x')

--- a/packages/frontend/test/utils/formatters/unpadHexString.test.ts
+++ b/packages/frontend/test/utils/formatters/unpadHexString.test.ts
@@ -1,0 +1,19 @@
+import { unpadHexString } from 'src/utils/formatters/unpadHexString'
+
+describe('unpadHexString', () => {
+  it('Leaves an unpadded string as-is', () => {
+    expect(unpadHexString('0x1a')).toEqual('0x1a')
+  })
+
+  it('Removes a single zero padding', () => {
+    expect(unpadHexString('0x0f')).toEqual('0xf')
+  })
+
+  it('Removes multiple zeroes', () => {
+    expect(unpadHexString('0x000f')).toEqual('0xf')
+  })
+
+  it('Removes all zeroes from a zero value', () => {
+    expect(unpadHexString('0x0000')).toEqual('0x')
+  })
+})


### PR DESCRIPTION
`BigNumber.toHexString()` always returns a hexstring with an even amount of nibbles, which sometimes results in a value that has a leading zero after the `0x` part (e.g. `0x066eeb` for ArbiRinkeby). Metamask's chain switching functions expect a "0x-prefixed, unpadded, non-zero hexadecimal string", so it throws when it receives the above input.
This just adds a tiny function that ensures Metamask won't throw an error.