### PR TITLE
🍄 Prevent account switch from flashing a wrong component

### DIFF
--- a/packages/frontend/src/components/Bid/BumpBid/BumpBidFlow.tsx
+++ b/packages/frontend/src/components/Bid/BumpBid/BumpBidFlow.tsx
@@ -44,7 +44,7 @@ export const BumpBidFlow = () => {
 
   return (
     <>
-      {view === TxFlowSteps.Placing && userBid && newBidAmount ? (
+      {view === TxFlowSteps.Placing ? (
         <BumpBidForm
           userBid={userBid}
           newBidAmount={newBidAmount}

--- a/packages/frontend/src/components/Bid/BumpBid/BumpBidForm.tsx
+++ b/packages/frontend/src/components/Bid/BumpBid/BumpBidForm.tsx
@@ -6,14 +6,15 @@ import { Button } from 'src/components/Buttons/Button'
 import { Separator } from 'src/components/common/Separator'
 import { Form, FormHeading, FormRow, FormWrapper } from 'src/components/Form/Form'
 import { Input } from 'src/components/Form/Input'
+import { ZERO } from 'src/constants/bigNumber'
 import type { Bid } from 'src/models/Bid'
 import { formatEtherAmount } from 'src/utils/formatters/formatEtherAmount'
 import { getPositionAfterBump } from 'src/utils/getPositionAfterBump'
 import styled from 'styled-components'
 
 interface BumpBidProps {
-  userBid: Bid
-  newBidAmount: BigNumber
+  userBid?: Bid
+  newBidAmount?: BigNumber
   bumpAmount: string
   parsedBumpAmount: BigNumber
   minimumIncrement: BigNumber
@@ -24,7 +25,7 @@ interface BumpBidProps {
 
 export const BumpBidForm = ({
   userBid,
-  newBidAmount,
+  newBidAmount = ZERO,
   bumpAmount,
   parsedBumpAmount,
   minimumIncrement,
@@ -43,11 +44,11 @@ export const BumpBidForm = ({
       <BumpForm>
         <FormRow>
           <span>Your current bid</span>
-          <span>{formatEtherAmount(userBid.amount)} ETH</span>
+          <span>{formatEtherAmount(userBid?.amount ?? ZERO)} ETH</span>
         </FormRow>
         <FormRow>
           <span>Current place in the raffle</span>
-          <span>No. {userBid.place}</span>
+          <span>No. {userBid?.place}</span>
         </FormRow>
         <Input
           initialAmount={bumpAmount}
@@ -66,7 +67,9 @@ export const BumpBidForm = ({
         </FormRow>
         <FormRow>
           <span>Place in the raffle after the bump</span>
-          <span>No. {bidTooLow ? userBid.place : getPositionAfterBump(newBidAmount, userBid.bidderID, bids)}</span>
+          <span>
+            No. {userBid && (bidTooLow ? userBid.place : getPositionAfterBump(newBidAmount, userBid.bidderID, bids))}
+          </span>
         </FormRow>
         <Button
           disabled={notEnoughBalance || bidTooLow}


### PR DESCRIPTION
I tried a couple of approaches but none of them worked, so I decided to just settle for BumpBidForm accepting undefined values.