### PR TITLE
🌱 Change view lock logic

### DIFF
--- a/packages/frontend/src/components/Auction/AuctionTransaction.tsx
+++ b/packages/frontend/src/components/Auction/AuctionTransaction.tsx
@@ -23,7 +23,7 @@ interface AuctionTransactionProps {
   impact?: BigNumber
   view: TxFlowSteps
   setView: (state: TxFlowSteps) => void
-  endInitialBidding?: () => void
+  setTransactionViewLock?: (val: boolean) => void
 }
 
 export const AuctionTransaction = ({
@@ -32,10 +32,12 @@ export const AuctionTransaction = ({
   impact,
   view,
   setView,
-  endInitialBidding,
+  setTransactionViewLock: setTransactionViewLock,
 }: AuctionTransactionProps) => {
   const [txHash, setTxHash] = useState('')
   const isFailed = isTxFailed(action.state)
+  const lockViewOnTransaction = () => setTransactionViewLock?.(true)
+  const unlockViewFromTransaction = () => setTransactionViewLock?.(false)
 
   return (
     <Transaction>
@@ -54,6 +56,7 @@ export const AuctionTransaction = ({
             setTxHash={setTxHash}
             view={view}
             setView={setView}
+            lockViewOnTransaction={lockViewOnTransaction}
           />
         )}
         {view === TxFlowSteps.Confirmation && (
@@ -61,7 +64,7 @@ export const AuctionTransaction = ({
             action={action.type}
             txHash={txHash}
             setView={setView}
-            endInitialBidding={endInitialBidding}
+            unlockViewFromTransaction={unlockViewFromTransaction}
           />
         )}
       </TransactionWrapper>

--- a/packages/frontend/src/components/Bid/BidFlow.tsx
+++ b/packages/frontend/src/components/Bid/BidFlow.tsx
@@ -1,15 +1,27 @@
-import { useEthers } from '@usedapp/core'
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { BumpBidFlow } from 'src/components/Bid/BumpBid/BumpBidFlow'
 import { PlaceBidFlow } from 'src/components/Bid/PlaceBid/PlaceBidFlow'
 import { useUserBid } from 'src/hooks/useUserBid'
 
 export const BidFlow = () => {
-  const { account } = useEthers()
   const userBid = useUserBid()
-  const [isInitialBid, setIsInitialBid] = useState(!userBid)
-  const endInitialBidding = useCallback(() => setIsInitialBid(false), [setIsInitialBid])
-  useEffect(() => setIsInitialBid(!userBid), [account]) // eslint-disable-line react-hooks/exhaustive-deps
+  const [isTransactionViewLock, setTransactionViewLock] = useState(false)
 
-  return isInitialBid ? <PlaceBidFlow endInitialBidding={endInitialBidding} /> : <BumpBidFlow />
+  const [isInitialBid, setIsInitialBid] = useState<boolean>(true)
+  useEffect(() => {
+    if (!isTransactionViewLock) {
+      setIsInitialBid(!userBid)
+    }
+  }, [isTransactionViewLock, !userBid]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return isInitialBid ? (
+    <PlaceBidFlow setTransactionViewLock={setTransactionViewLock} />
+  ) : (
+    <BumpBidFlow setTransactionViewLock={setTransactionViewLock} />
+  )
 }
+
+export interface FlowProps {
+  setTransactionViewLock: (value: boolean) => void
+}
+type BidFlow = (props: FlowProps) => JSX.Element

--- a/packages/frontend/src/components/Bid/BidFlow.tsx
+++ b/packages/frontend/src/components/Bid/BidFlow.tsx
@@ -7,7 +7,7 @@ export const BidFlow = () => {
   const userBid = useUserBid()
   const [isTransactionViewLock, setTransactionViewLock] = useState(false)
 
-  const [isInitialBid, setIsInitialBid] = useState<boolean>(true)
+  const [isInitialBid, setIsInitialBid] = useState<boolean>(!userBid)
   useEffect(() => {
     if (!isTransactionViewLock) {
       setIsInitialBid(!userBid)

--- a/packages/frontend/src/components/Bid/BidFlow.tsx
+++ b/packages/frontend/src/components/Bid/BidFlow.tsx
@@ -24,4 +24,3 @@ export const BidFlow = () => {
 export interface FlowProps {
   setTransactionViewLock: (value: boolean) => void
 }
-type BidFlow = (props: FlowProps) => JSX.Element

--- a/packages/frontend/src/components/Bid/BumpBid/BumpBidFlow.tsx
+++ b/packages/frontend/src/components/Bid/BumpBid/BumpBidFlow.tsx
@@ -11,7 +11,9 @@ import { useMinimumIncrement } from 'src/hooks/useMinimumIncrement'
 import { useUserBid } from 'src/hooks/useUserBid'
 import { prepareAmountForParsing } from 'src/utils/prepareAmountForParsing'
 
-export const BumpBidFlow = () => {
+import { FlowProps } from '../BidFlow'
+
+export const BumpBidFlow = ({ setTransactionViewLock }: FlowProps) => {
   const userBid = useUserBid()
   const minimumIncrement = useMinimumIncrement()
   const { placeBid, state, resetState } = useBid()
@@ -62,6 +64,7 @@ export const BumpBidFlow = () => {
           impact={newBidAmount}
           view={view}
           setView={setView}
+          setTransactionViewLock={setTransactionViewLock}
         />
       )}
     </>

--- a/packages/frontend/src/components/Bid/PlaceBid/PlaceBidFlow.tsx
+++ b/packages/frontend/src/components/Bid/PlaceBid/PlaceBidFlow.tsx
@@ -10,11 +10,9 @@ import { useBids } from 'src/hooks/useBids'
 import { useMinimumBid } from 'src/hooks/useMinimumBid'
 import { prepareAmountForParsing } from 'src/utils/prepareAmountForParsing'
 
-interface PlaceBidFlowProps {
-  endInitialBidding: () => void
-}
+import { FlowProps } from '../BidFlow'
 
-export const PlaceBidFlow = ({ endInitialBidding }: PlaceBidFlowProps) => {
+export const PlaceBidFlow = ({ setTransactionViewLock }: FlowProps) => {
   const [view, setView] = useState<TxFlowSteps>(TxFlowSteps.Placing)
   const minimumBid = useMinimumBid()
   const [bid, setBid] = useState('0')
@@ -58,7 +56,7 @@ export const PlaceBidFlow = ({ endInitialBidding }: PlaceBidFlowProps) => {
           amount={parsedBid}
           view={view}
           setView={setView}
-          endInitialBidding={endInitialBidding}
+          setTransactionViewLock={setTransactionViewLock}
         />
       )}
     </>

--- a/packages/frontend/src/components/Form/ReviewForm.tsx
+++ b/packages/frontend/src/components/Form/ReviewForm.tsx
@@ -23,9 +23,18 @@ interface ReviewFormProps {
   setTxHash: (hash: string) => void
   view: TxFlowSteps
   setView: (state: TxFlowSteps) => void
+  lockViewOnTransaction?: () => void
 }
 
-export const ReviewForm = ({ action, amount, impact, setTxHash, view, setView }: ReviewFormProps) => {
+export const ReviewForm = ({
+  action,
+  amount,
+  impact,
+  setTxHash,
+  view,
+  setView,
+  lockViewOnTransaction,
+}: ReviewFormProps) => {
   const { account } = useEthers()
   const etherBalance = useEtherBalance(account)
   const isPending = isTxPending(action.state)
@@ -40,6 +49,11 @@ export const ReviewForm = ({ action, amount, impact, setTxHash, view, setView }:
       action.resetState()
     }
   }, [view, setView, setTxHash, action])
+
+  const sendTransaction = () => {
+    action.send()
+    lockViewOnTransaction?.()
+  }
 
   return (
     <FormNarrow>
@@ -57,7 +71,7 @@ export const ReviewForm = ({ action, amount, impact, setTxHash, view, setView }:
         <span>Wallet Balance</span>
         <span>{etherBalance && formatEtherAmount(etherBalance)} ETH</span>
       </FormRow>
-      <Button view="primary" isLoading={isPending} onClick={() => action.send()}>
+      <Button view="primary" isLoading={isPending} onClick={sendTransaction}>
         {heading[action.type]}
       </Button>
     </FormNarrow>

--- a/packages/frontend/src/components/Transaction/TransactionSuccess.tsx
+++ b/packages/frontend/src/components/Transaction/TransactionSuccess.tsx
@@ -14,16 +14,16 @@ interface Props {
   txHash: string
   action: Transactions
   setView: (state: TxFlowSteps) => void
-  endInitialBidding?: () => void
+  unlockViewFromTransaction?: () => void
 }
 
-export const TransactionSuccess = ({ txHash, action, setView, endInitialBidding }: Props) => {
+export const TransactionSuccess = ({ txHash, action, setView, unlockViewFromTransaction }: Props) => {
   const chainId = useChainId()
   const transactionLink = getExplorerTxLink(chainId, txHash)
 
   const goHome = () => {
     setView(0)
-    endInitialBidding && endInitialBidding()
+    unlockViewFromTransaction?.()
   }
 
   return (


### PR DESCRIPTION
This was an incorrect solution to the problem addressed in #134. Still, it might be beneficial to use this code.
Basically, the previous logic for staying on transaction receipt of Place Bid transaction was a little iffy, and it didn't prevent the transaction receipt (or transaction mining view) from disappearing when account was changed. This solution locks view on transaction mining/transaction receipt view in bid flows until the home button is pressed.