### PR TITLE
🙅 Make MaxHeap methods internal

### DIFF
--- a/packages/contracts/contracts/libs/MaxHeap.sol
+++ b/packages/contracts/contracts/libs/MaxHeap.sol
@@ -9,7 +9,7 @@ pragma solidity 0.8.10;
  * @author TrueFi Engineering team
  */
 library MaxHeap {
-    function insert(uint256[] storage heap, uint256 key) public {
+    function insert(uint256[] storage heap, uint256 key) internal {
         uint256 index = heap.length;
         heap.push(key);
         bubbleUp(heap, index, key);
@@ -19,7 +19,7 @@ library MaxHeap {
         uint256[] storage heap,
         uint256 oldValue,
         uint256 newValue
-    ) public {
+    ) internal {
         uint256 index = findKey(heap, oldValue);
         increaseKeyAt(heap, index, newValue);
     }
@@ -28,13 +28,13 @@ library MaxHeap {
         uint256[] storage heap,
         uint256 index,
         uint256 newValue
-    ) public {
+    ) internal {
         require(newValue > heap[index], "MaxHeap: new value must be bigger than old value");
         heap[index] = newValue;
         bubbleUp(heap, index, newValue);
     }
 
-    function removeMax(uint256[] storage heap) public returns (uint256 max) {
+    function removeMax(uint256[] storage heap) internal returns (uint256 max) {
         require(heap.length > 0, "MaxHeap: cannot remove max element from empty heap");
         max = heap[0];
         heap[0] = heap[heap.length - 1];
@@ -61,7 +61,7 @@ library MaxHeap {
         return max;
     }
 
-    function findKey(uint256[] storage heap, uint256 value) public view returns (uint256) {
+    function findKey(uint256[] storage heap, uint256 value) internal view returns (uint256) {
         for (uint256 i = 0; i < heap.length; ++i) {
             if (heap[i] == value) {
                 return i;
@@ -70,7 +70,7 @@ library MaxHeap {
         revert("MaxHeap: key with given value not found");
     }
 
-    function findMin(uint256[] storage heap) public view returns (uint256 index, uint256 min) {
+    function findMin(uint256[] storage heap) internal view returns (uint256 index, uint256 min) {
         uint256 heapLength = heap.length;
         require(heapLength > 0, "MaxHeap: cannot find minimum element on empty heap");
 

--- a/packages/contracts/contracts/libs/MaxHeap.sol
+++ b/packages/contracts/contracts/libs/MaxHeap.sol
@@ -61,6 +61,17 @@ library MaxHeap {
         return max;
     }
 
+    function bubbleUp(
+        uint256[] storage heap,
+        uint256 index,
+        uint256 key
+    ) internal {
+        while (index > 0 && heap[parent(index)] < heap[index]) {
+            (heap[parent(index)], heap[index]) = (key, heap[parent(index)]);
+            index = parent(index);
+        }
+    }
+
     function findKey(uint256[] storage heap, uint256 value) internal view returns (uint256) {
         for (uint256 i = 0; i < heap.length; ++i) {
             if (heap[i] == value) {
@@ -84,17 +95,6 @@ library MaxHeap {
                 min = element;
                 index = i;
             }
-        }
-    }
-
-    function bubbleUp(
-        uint256[] storage heap,
-        uint256 index,
-        uint256 key
-    ) internal {
-        while (index > 0 && heap[parent(index)] < heap[index]) {
-            (heap[parent(index)], heap[index]) = (key, heap[parent(index)]);
-            index = parent(index);
         }
     }
 

--- a/packages/contracts/scripts/deploy/deploy.ts
+++ b/packages/contracts/scripts/deploy/deploy.ts
@@ -24,8 +24,7 @@ export async function deployAuctionRaffle(biddingStartTime: number, deployer: Si
   const biddingEndTime = biddingStartTime + minStateDuration
   const claimingEndTime = biddingEndTime + minStateDuration
 
-  const libraryLink = await deployMaxHeap(deployer, hre)
-  const auctionRaffleFactory = await hre.ethers.getContractFactory(auctionRaffleArtifactName, { libraries: libraryLink })
+  const auctionRaffleFactory = await hre.ethers.getContractFactory(auctionRaffleArtifactName)
   return auctionRaffleFactory.connect(deployer).deploy(
     deployer.address,
     biddingStartTime,
@@ -42,7 +41,7 @@ export async function deployTestnetAuctionRaffle(biddingStartTime: number, heapL
   const biddingEndTime = biddingStartTime + YEAR
   const claimingEndTime = biddingEndTime + minStateDuration
 
-  const auctionRaffleFactory = await hre.ethers.getContractFactory(auctionRaffleArtifactName, { libraries: getAuctionRaffleLibraries(heapLibraryAddress) })
+  const auctionRaffleFactory = await hre.ethers.getContractFactory(auctionRaffleArtifactName)
   return auctionRaffleFactory.connect(deployer).deploy(
     deployer.address,
     biddingStartTime,
@@ -53,12 +52,4 @@ export async function deployTestnetAuctionRaffle(biddingStartTime: number, heapL
     utils.parseUnits('0.15', 9),
     utils.parseUnits('0.01', 9),
   )
-}
-
-export async function deployMaxHeap(deployer: Signer, hre: HardhatRuntimeEnvironment) {
-  const heapLibraryFactory = await hre.ethers.getContractFactory('MaxHeap')
-  const heapLibrary = await heapLibraryFactory.connect(deployer).deploy()
-  console.log('\nMaxHeap address: ', heapLibrary.address)
-
-  return getAuctionRaffleLibraries(heapLibrary.address)
 }

--- a/packages/contracts/scripts/deploy/deploy.ts
+++ b/packages/contracts/scripts/deploy/deploy.ts
@@ -37,7 +37,7 @@ export async function deployAuctionRaffle(biddingStartTime: number, deployer: Si
   )
 }
 
-export async function deployTestnetAuctionRaffle(biddingStartTime: number, heapLibraryAddress: string, deployer: SignerWithAddress, hre: HardhatRuntimeEnvironment) {
+export async function deployTestnetAuctionRaffle(biddingStartTime: number, deployer: SignerWithAddress, hre: HardhatRuntimeEnvironment) {
   const biddingEndTime = biddingStartTime + YEAR
   const claimingEndTime = biddingEndTime + minStateDuration
 

--- a/packages/contracts/scripts/deploy/deploy.ts
+++ b/packages/contracts/scripts/deploy/deploy.ts
@@ -1,8 +1,8 @@
-import { Contract, Signer, utils } from 'ethers'
+import { Contract, utils } from 'ethers'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { HOUR, YEAR } from 'scripts/utils/consts'
-import { auctionRaffleArtifactName, getAuctionRaffleLibraries, multicallArtifactName } from 'scripts/utils/auctionRaffle'
+import { auctionRaffleArtifactName, multicallArtifactName } from 'scripts/utils/auctionRaffle'
 
 export const reservePrice = utils.parseEther('0.15')
 export const minBidIncrement = utils.parseEther('0.01')

--- a/packages/contracts/scripts/tasks/auctionRaffle/hardhatTasks.ts
+++ b/packages/contracts/scripts/tasks/auctionRaffle/hardhatTasks.ts
@@ -1,5 +1,5 @@
 import { task, types } from 'hardhat/config'
-import { connectToAuctionRaffle, auctionRaffleAddress, heapAddress } from 'scripts/utils/auctionRaffle'
+import { auctionRaffleAddress, connectToAuctionRaffle } from 'scripts/utils/auctionRaffle'
 import { BigNumber, BigNumberish, constants, Contract, utils } from 'ethers'
 import { parseEther } from 'ethers/lib/utils'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
@@ -18,7 +18,7 @@ task('bid', 'Places bid for given account with provided amount')
     hre,
   ) => {
     const signer = await hre.ethers.getSigner(account)
-    const auctionRaffle = await connectToAuctionRaffle(hre, auctionRaffleAddress, heapAddress)
+    const auctionRaffle = await connectToAuctionRaffle(hre, auctionRaffleAddress)
     const auctionRaffleAsSigner = auctionRaffle.connect(signer)
 
     const ethAmount = parseEther(amount)
@@ -34,7 +34,7 @@ task('bid-random', 'Bids X times using randomly generated accounts')
     hre,
   ) => {
     const signers = await hre.ethers.getSigners()
-    const auctionRaffle = await connectToAuctionRaffle(hre, auctionRaffleAddress, heapAddress)
+    const auctionRaffle = await connectToAuctionRaffle(hre, auctionRaffleAddress)
 
     console.log('Generating accounts...')
     const randomAccounts = generateRandomAccounts(amount, hre.ethers.provider)
@@ -78,7 +78,7 @@ function formatEther(amount: BigNumberish): string {
 
 async function auctionRaffleAsOwner(hre: HardhatRuntimeEnvironment): Promise<Contract> {
   const owner = await getAuctionRaffleOwner(hre)
-  const auctionRaffle = await connectToAuctionRaffle(hre, auctionRaffleAddress, heapAddress)
+  const auctionRaffle = await connectToAuctionRaffle(hre, auctionRaffleAddress)
   return auctionRaffle.connect(owner)
 }
 

--- a/packages/contracts/scripts/tasks/auctionRaffle/rinkebyTasks.ts
+++ b/packages/contracts/scripts/tasks/auctionRaffle/rinkebyTasks.ts
@@ -6,7 +6,6 @@ import { connectToAuctionRaffle } from 'scripts/utils/auctionRaffle'
 import writeFileAtomic from 'write-file-atomic'
 
 const testnetAuctionRaffleAddress = '0xe4fbda3E853F6DBBFc42D6D66eB030F2Be203d7F'
-const testnetHeapAddress = '0xc1D8b72838Cb3F1c52651d76ea186Df457817aD6'
 
 task('generate-dotenv', 'Generate .env file needed for other tasks')
   .addParam('path', 'location of the file', '../../.env', types.string)
@@ -45,7 +44,7 @@ task('deploy', 'Deploys AuctionRaffle contract')
     console.log('Deploying contracts...')
     const now = Math.floor(Date.now() / 1000)
     const biddingStartTime = now + delay
-    const auctionRaffle = await deployTestnetAuctionRaffle(biddingStartTime, testnetHeapAddress, deployer, hre)
+    const auctionRaffle = await deployTestnetAuctionRaffle(biddingStartTime, deployer, hre)
     console.log('AuctionRaffle address: ', auctionRaffle.address)
     console.log('Contracts deployed\n')
   })
@@ -56,7 +55,7 @@ task('init-bids', 'Places initial bids using PRIVATE_KEYS accounts')
     const initialBidAmount = utils.parseUnits('0.20', 9)
     const bidIncrement = utils.parseUnits('0.02', 9)
 
-    const auctionRaffle = await connectToAuctionRaffle(hre, getTestnetAuctionRaffleAddress(), testnetHeapAddress)
+    const auctionRaffle = await connectToAuctionRaffle(hre, getTestnetAuctionRaffleAddress())
 
     const privateKeys: string[] = JSON.parse(process.env.PRIVATE_KEYS)
     for (let i = 0; i < privateKeys.length; i++) {

--- a/packages/contracts/scripts/tasks/auctionRaffle/rinkebyTasks.ts
+++ b/packages/contracts/scripts/tasks/auctionRaffle/rinkebyTasks.ts
@@ -5,7 +5,7 @@ import { formatEther, parseEther } from 'ethers/lib/utils'
 import { connectToAuctionRaffle } from 'scripts/utils/auctionRaffle'
 import writeFileAtomic from 'write-file-atomic'
 
-const testnetAuctionRaffleAddress = '0xe4fbda3E853F6DBBFc42D6D66eB030F2Be203d7F'
+const testnetAuctionRaffleAddress = '0x17c9FE0c1B4d6dCC61f71064095e60b7A87514cF'
 
 task('generate-dotenv', 'Generate .env file needed for other tasks')
   .addParam('path', 'location of the file', '../../.env', types.string)

--- a/packages/contracts/scripts/utils/auctionRaffle.ts
+++ b/packages/contracts/scripts/utils/auctionRaffle.ts
@@ -2,7 +2,7 @@ import { HardhatRuntimeEnvironment } from 'hardhat/types'
 
 export const heapAddress = '0x5FbDB2315678afecb367f032d93F642f64180aa3'
 export const heapArtifactName = 'contracts/libs/MaxHeap.sol:MaxHeap'
-export const auctionRaffleAddress = '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512'
+export const auctionRaffleAddress = '0x5FbDB2315678afecb367f032d93F642f64180aa3'
 export const auctionRaffleArtifactName = 'contracts/AuctionRaffle.sol:AuctionRaffle'
 export const multicallArtifactName = 'contracts/test/Multicall2.sol:Multicall2'
 

--- a/packages/contracts/scripts/utils/auctionRaffle.ts
+++ b/packages/contracts/scripts/utils/auctionRaffle.ts
@@ -1,18 +1,10 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 
-export const heapAddress = '0x5FbDB2315678afecb367f032d93F642f64180aa3'
-export const heapArtifactName = 'contracts/libs/MaxHeap.sol:MaxHeap'
 export const auctionRaffleAddress = '0x5FbDB2315678afecb367f032d93F642f64180aa3'
 export const auctionRaffleArtifactName = 'contracts/AuctionRaffle.sol:AuctionRaffle'
 export const multicallArtifactName = 'contracts/test/Multicall2.sol:Multicall2'
 
-export async function connectToAuctionRaffle(hre: HardhatRuntimeEnvironment, auctionRaffleAddress: string, heapAddress: string) {
-  const auctionRaffleFactory = await hre.ethers.getContractFactory(auctionRaffleArtifactName, { libraries: getAuctionRaffleLibraries(heapAddress) })
+export async function connectToAuctionRaffle(hre: HardhatRuntimeEnvironment, auctionRaffleAddress: string) {
+  const auctionRaffleFactory = await hre.ethers.getContractFactory(auctionRaffleArtifactName)
   return auctionRaffleFactory.attach(auctionRaffleAddress)
-}
-
-export function getAuctionRaffleLibraries(maxHeapAddress: string) {
-  return {
-    [heapArtifactName]: maxHeapAddress,
-  }
 }

--- a/packages/contracts/test/fixtures/auctionRaffleFixture.ts
+++ b/packages/contracts/test/fixtures/auctionRaffleFixture.ts
@@ -3,7 +3,6 @@ import { BigNumberish, utils, Wallet } from 'ethers'
 import { MockProvider } from 'ethereum-waffle'
 import { getLatestBlockTimestamp } from 'utils/getLatestBlockTimestamp'
 import { WEEK } from 'scripts/utils/consts'
-import { deployMaxHeap } from 'fixtures/maxHeapMockFixture'
 
 export const auctionWinnersCount = 1
 export const raffleWinnersCount = 8
@@ -45,8 +44,7 @@ export function configuredAuctionRaffleFixture(params: auctionRaffleParams) {
     const currentBlockTimestamp = await getLatestBlockTimestamp(provider)
     params = setAuctionRaffleParamsDefaults(owner, currentBlockTimestamp, params)
 
-    const libraryLink = await deployMaxHeap(deployer)
-    const auctionRaffle = await new AuctionRaffleMock__factory(libraryLink, deployer).deploy(
+    const auctionRaffle = await new AuctionRaffleMock__factory(deployer).deploy(
       params.initialOwner,
       params.biddingStartTime,
       params.biddingEndTime,

--- a/packages/contracts/test/fixtures/maxHeapMockFixture.ts
+++ b/packages/contracts/test/fixtures/maxHeapMockFixture.ts
@@ -1,21 +1,9 @@
-import { Signer, Wallet } from 'ethers'
+import { Wallet } from 'ethers'
 import { MockProvider } from 'ethereum-waffle'
 import { MaxHeapMock__factory } from 'contracts'
-import { ethers } from 'hardhat'
 
 export async function maxHeapMockFixture([deployer]: Wallet[], provider: MockProvider) {
-  const libraryLink = await deployMaxHeap(deployer)
-  const heap = await new MaxHeapMock__factory(libraryLink, deployer).deploy()
+  const heap = await new MaxHeapMock__factory(deployer).deploy()
 
   return { heap, provider }
-}
-
-export async function deployMaxHeap(deployer: Signer) {
-  const heapLibraryFactory = await ethers.getContractFactory('MaxHeap')
-  const heapLibrary = await heapLibraryFactory.connect(deployer).deploy()
-
-  return {
-    'contracts/libs/MaxHeap.sol:MaxHeap': heapLibrary.address,
-    __$3ef75435bd6f8696a9a70764ef1093bd01$__: heapLibrary.address,
-  }
 }

--- a/packages/frontend/src/config/addresses.ts
+++ b/packages/frontend/src/config/addresses.ts
@@ -12,7 +12,7 @@ export const ADDRESSES: Record<string, Record<SupportedChainId, string>> = {
   },
   devcon: {
     [ChainId.Arbitrum]: '',
-    [ChainId.ArbitrumRinkeby]: '0xe4fbda3E853F6DBBFc42D6D66eB030F2Be203d7F',
+    [ChainId.ArbitrumRinkeby]: '0x17c9FE0c1B4d6dCC61f71064095e60b7A87514cF',
     [ChainId.Hardhat]: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
   },
 }

--- a/packages/frontend/src/config/addresses.ts
+++ b/packages/frontend/src/config/addresses.ts
@@ -8,12 +8,12 @@ export const ADDRESSES: Record<string, Record<SupportedChainId, string>> = {
   multicall: {
     [ChainId.Arbitrum]: '0x842eC2c7D803033Edf55E478F461FC547Bc54EB2',
     [ChainId.ArbitrumRinkeby]: '0x5D6e06d3E154C5DBEC91317f0d04AE03AB49A273',
-    [ChainId.Hardhat]: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+    [ChainId.Hardhat]: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
   },
   devcon: {
     [ChainId.Arbitrum]: '',
     [ChainId.ArbitrumRinkeby]: '0xe4fbda3E853F6DBBFc42D6D66eB030F2Be203d7F',
-    [ChainId.Hardhat]: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
+    [ChainId.Hardhat]: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
   },
 }
 


### PR DESCRIPTION
This is done to embed the library instead of linking it.
As part of this PR we had to make changes to deployment scripts that no longer need to deploy `MaxHeap` separately. As a result the address of local deployment changed. We also redeployed the contract to Arbitrum Rinkeby.