### PR TITLE
🧮 Add script for generating random numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ A number of custom Hardhat tasks were defined to aid testing.
 - `yarn rinkeby:init-bids` - place initial bids using `PRIVATE_KEYS` accounts
 
 #### Ethereum Mainnet
-- `yarn ethereum:generate-random-numbers --blocks <ARRAY> --secret <INT>` - generate random numbers for raffle settlement, *blocks* - array of block numbers from which extract block hash (e.g. "[1234, 5678]"), *secret* - secret number that will be used to generate numbers
+- `yarn ethereum:generate-random-numbers --blocks <ARRAY> --secret <STRING>` - generate random numbers for raffle settlement, *blocks* - array of block numbers from which extract block hash (e.g. "[1234, 5678]"), *secret* - secret number represented as 32 bytes hex string
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ A number of custom Hardhat tasks were defined to aid testing.
 - `yarn rinkeby:generate-dotenv [--path <STRING>] [--count <INT>]` - generate .env file needed for other tasks, *path* - output path, *count* - number of private keys to generate
 - `yarn rinkeby:transfer-ether` - transfer ether from `DEPLOYER` to `PRIVATE_KEYS` accounts
 - `yarn rinkeby:init-bids` - place initial bids using `PRIVATE_KEYS` accounts
+
+#### Ethereum Mainnet
+- `yarn ethereum:generate-random-numbers --blocks <ARRAY> --secret <INT>` - generate random numbers for raffle settlement, *blocks* - array of block numbers from which extract block hash (e.g. "[1234, 5678]"), *secret* - secret number that will be used to generate numbers
+

--- a/packages/contracts/contracts/test/Hashing.sol
+++ b/packages/contracts/contracts/test/Hashing.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.10;
+
+contract Hashing {
+    function hashTwo(bytes32 first, bytes32 second) public pure returns (bytes32) {
+        return keccak256(bytes.concat(first, second));
+    }
+}

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -37,6 +37,9 @@ module.exports = {
     rinkeby: {
       url: 'https://rinkeby.arbitrum.io/rpc',
       accounts: [process.env.DEPLOYER || zeroPrivateKey]
+    },
+    ethereum: {
+      url: 'https://eth-mainnet.alchemyapi.io/v2/j_dccrP25UjZv5uYxh1mcjEl5o8nWZaf'
     }
   },
   typechain: {

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -4,6 +4,7 @@ import './abi-exporter'
 import 'tsconfig-paths/register'
 import 'hardhat-gas-reporter'
 import 'scripts/tasks/nodeTasks'
+import 'scripts/tasks/auctionRaffle/ethereumTasks'
 import 'scripts/tasks/auctionRaffle/hardhatTasks'
 import 'scripts/tasks/auctionRaffle/rinkebyTasks'
 

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -38,6 +38,8 @@
     "rinkeby:transfer-ether": "hardhat --network rinkeby transfer-ether",
     "rinkeby:init-bids": "hardhat --network rinkeby init-bids",
 
+    "ethereum:generate-random-numbers": "hardhat --network ethereum generate-random-numbers",
+
     "mars:deploy": "bash scripts/mars/marsDeploy.sh scripts/mars/deploy.ts -n arbitrum"
   },
   "devDependencies": {

--- a/packages/contracts/scripts/tasks/auctionRaffle/ethereumTasks.ts
+++ b/packages/contracts/scripts/tasks/auctionRaffle/ethereumTasks.ts
@@ -2,12 +2,6 @@ import { task, types } from 'hardhat/config'
 import { BigNumber, utils } from 'ethers'
 import { EthereumProvider } from 'hardhat/types'
 
-interface Block {
-  hash: string,
-}
-
-type GetBlockNumberResponse = Block | undefined | null
-
 task('generate-random-numbers', 'Generates random numbers')
   .addParam('blocks', 'Array of block numbers', undefined, types.json)
   .addParam('secret', 'Secret number', undefined, types.int)
@@ -29,6 +23,10 @@ task('generate-random-numbers', 'Generates random numbers')
 
 async function getBlockHash(provider: EthereumProvider, blockNumber: number) {
   const hexBlockNumber = BigNumber.from(blockNumber).toHexString()
-  const block: GetBlockNumberResponse = await provider.send('eth_getBlockByNumber', [hexBlockNumber, true])
-  return block.hash
+  const response = await provider.send('eth_getBlockByNumber', [hexBlockNumber, true])
+  if (('hash' in response)) {
+    return response.hash
+  }
+  console.log('RPC node response: ', response)
+  throw new Error('Missing hash in RPC node response')
 }

--- a/packages/contracts/scripts/tasks/auctionRaffle/ethereumTasks.ts
+++ b/packages/contracts/scripts/tasks/auctionRaffle/ethereumTasks.ts
@@ -2,22 +2,30 @@ import { task, types } from 'hardhat/config'
 import { BigNumber, utils } from 'ethers'
 import { EthereumProvider } from 'hardhat/types'
 
+interface Result {
+  blockHash: string,
+  randomNumber: BigNumber,
+}
+
 task('generate-random-numbers', 'Generates random numbers')
   .addParam('blocks', 'Array of block numbers', undefined, types.json)
   .addParam('secret', 'Secret number', undefined, types.int)
   .setAction(async ({ blocks, secret }: { blocks: number[], secret: number }, hre) => {
     const provider = hre.network.provider
     const hexSecret = BigNumber.from(secret).toHexString().substring(2)
-    const randomNumbers: BigNumber[] = []
+    const results: Result[] = []
 
     for (const block of blocks) {
       const blockHash = await getBlockHash(provider, block)
       const randomNumberHash = utils.keccak256(blockHash.concat(hexSecret))
-      randomNumbers.push(BigNumber.from(randomNumberHash))
+      results.push({
+        blockHash,
+        randomNumber: BigNumber.from(randomNumberHash),
+      })
     }
 
-    randomNumbers.forEach((randomNumber, index) => {
-      console.log(`Random number for block #${blocks[index]}: ${randomNumber}`)
+    results.forEach((result, index) => {
+      console.log(`Random number for block #${blocks[index]} with hash ${result.blockHash}: ${result.randomNumber}`)
     })
   })
 

--- a/packages/contracts/scripts/tasks/auctionRaffle/ethereumTasks.ts
+++ b/packages/contracts/scripts/tasks/auctionRaffle/ethereumTasks.ts
@@ -1,40 +1,51 @@
-import { task, types } from 'hardhat/config'
+import { task } from 'hardhat/config'
 import { BigNumber, utils } from 'ethers'
 import { EthereumProvider } from 'hardhat/types'
+import { bytes32, intArray } from 'scripts/utils/types'
+import { hashTwo } from 'scripts/utils/hashTwo'
 
 interface Result {
   blockHash: string,
-  randomNumber: BigNumber,
+  randomNumber: string,
 }
 
 task('generate-random-numbers', 'Generates random numbers')
-  .addParam('blocks', 'Array of block numbers', undefined, types.json)
-  .addParam('secret', 'Secret number', undefined, types.int)
-  .setAction(async ({ blocks, secret }: { blocks: number[], secret: number }, hre) => {
+  .addParam('blocks', 'Array of block numbers', undefined, intArray)
+  .addParam('secret', 'Secret number', undefined, bytes32)
+  .setAction(async ({ blocks, secret }: { blocks: number[], secret: string }, hre) => {
     const provider = hre.network.provider
-    const hexSecret = BigNumber.from(secret).toHexString().substring(2)
-    const results: Result[] = []
 
+    const results: Result[] = []
     for (const block of blocks) {
       const blockHash = await getBlockHash(provider, block)
-      const randomNumberHash = utils.keccak256(blockHash.concat(hexSecret))
-      results.push({
-        blockHash,
-        randomNumber: BigNumber.from(randomNumberHash),
-      })
+      const randomNumber = hashTwo(blockHash, secret)
+      results.push({ blockHash, randomNumber })
     }
 
     results.forEach((result, index) => {
       console.log(`Random number for block #${blocks[index]} with hash ${result.blockHash}: ${result.randomNumber}`)
     })
+
+    console.log(`\nRandom numbers as integer array: ${toIntArray(results)}`)
   })
 
-async function getBlockHash(provider: EthereumProvider, blockNumber: number) {
-  const hexBlockNumber = BigNumber.from(blockNumber).toHexString()
+async function getBlockHash(provider: EthereumProvider, blockNumber: number): Promise<string> {
+  const hexBlockNumber = utils.hexlify(blockNumber)
   const response = await provider.send('eth_getBlockByNumber', [hexBlockNumber, true])
-  if (('hash' in response)) {
-    return response.hash
+
+  if (!('hash' in response)) {
+    console.log('RPC node response: ', response)
+    throw new Error('Missing hash in RPC node response')
   }
-  console.log('RPC node response: ', response)
-  throw new Error('Missing hash in RPC node response')
+
+  if (!utils.isHexString(response.hash)) {
+    throw new Error('Invalid hash in RPC node response')
+  }
+
+  return response.hash
+}
+
+function toIntArray(results: Result[]): string {
+  const ints = results.map(({ randomNumber }) => BigNumber.from(randomNumber).toString()).join(',')
+  return '[' + ints + ']'
 }

--- a/packages/contracts/scripts/tasks/auctionRaffle/ethereumTasks.ts
+++ b/packages/contracts/scripts/tasks/auctionRaffle/ethereumTasks.ts
@@ -1,0 +1,34 @@
+import { task, types } from 'hardhat/config'
+import { BigNumber, utils } from 'ethers'
+import { EthereumProvider } from 'hardhat/types'
+
+interface Block {
+  hash: string,
+}
+
+type GetBlockNumberResponse = Block | undefined | null
+
+task('generate-random-numbers', 'Generates random numbers')
+  .addParam('blocks', 'Array of block numbers', undefined, types.json)
+  .addParam('secret', 'Secret number', undefined, types.int)
+  .setAction(async ({ blocks, secret }: { blocks: number[], secret: number }, hre) => {
+    const provider = hre.network.provider
+    const hexSecret = BigNumber.from(secret).toHexString().substring(2)
+    const randomNumbers: BigNumber[] = []
+
+    for (const block of blocks) {
+      const blockHash = await getBlockHash(provider, block)
+      const randomNumberHash = utils.keccak256(blockHash.concat(hexSecret))
+      randomNumbers.push(BigNumber.from(randomNumberHash))
+    }
+
+    randomNumbers.forEach((randomNumber, index) => {
+      console.log(`Random number for block #${blocks[index]}: ${randomNumber}`)
+    })
+  })
+
+async function getBlockHash(provider: EthereumProvider, blockNumber: number) {
+  const hexBlockNumber = BigNumber.from(blockNumber).toHexString()
+  const block: GetBlockNumberResponse = await provider.send('eth_getBlockByNumber', [hexBlockNumber, true])
+  return block.hash
+}

--- a/packages/contracts/scripts/tasks/nodeTasks.ts
+++ b/packages/contracts/scripts/tasks/nodeTasks.ts
@@ -1,5 +1,7 @@
 import { task, types } from 'hardhat/config'
 import { minStateDuration } from 'scripts/node/deploy'
+import { BigNumber, utils } from 'ethers'
+import { EthereumProvider } from 'hardhat/types'
 
 task('increase-time', 'Increases block time')
   .addParam('value', 'Time in seconds to increase', minStateDuration, types.int, true)
@@ -19,3 +21,34 @@ task('accounts', 'Prints available accounts')
     const signers = await hre.ethers.getSigners()
     signers.forEach((signer, index) => console.log(`Account #${index} ${signer.address}`))
   })
+
+interface Block {
+  hash: string,
+}
+
+type GetBlockNumberResponse = Block | undefined | null
+
+task('generate-random-numbers', 'Generates random numbers')
+  .addParam('blocks', 'Array of block numbers', undefined, types.json)
+  .addParam('secret', 'Secret number', undefined, types.int)
+  .setAction(async ({ blocks, secret }: { blocks: number[], secret: number }, hre) => {
+    const provider = hre.network.provider
+    const hexSecret = BigNumber.from(secret).toHexString().substring(2)
+    const randomNumbers: BigNumber[] = []
+
+    for (const block of blocks) {
+      const blockHash = await getBlockHash(provider, block)
+      const randomNumberHash = utils.keccak256(blockHash.concat(hexSecret))
+      randomNumbers.push(BigNumber.from(randomNumberHash))
+    }
+
+    randomNumbers.forEach((randomNumber, index) => {
+      console.log(`Random number for block #${blocks[index]}: ${randomNumber}`)
+    })
+  })
+
+async function getBlockHash(provider: EthereumProvider, blockNumber: number) {
+  const hexBlockNumber = BigNumber.from(blockNumber).toHexString()
+  const block: GetBlockNumberResponse = await provider.send('eth_getBlockByNumber', [hexBlockNumber, true])
+  return block.hash
+}

--- a/packages/contracts/scripts/tasks/nodeTasks.ts
+++ b/packages/contracts/scripts/tasks/nodeTasks.ts
@@ -1,7 +1,5 @@
 import { task, types } from 'hardhat/config'
 import { minStateDuration } from 'scripts/node/deploy'
-import { BigNumber, utils } from 'ethers'
-import { EthereumProvider } from 'hardhat/types'
 
 task('increase-time', 'Increases block time')
   .addParam('value', 'Time in seconds to increase', minStateDuration, types.int, true)
@@ -21,34 +19,3 @@ task('accounts', 'Prints available accounts')
     const signers = await hre.ethers.getSigners()
     signers.forEach((signer, index) => console.log(`Account #${index} ${signer.address}`))
   })
-
-interface Block {
-  hash: string,
-}
-
-type GetBlockNumberResponse = Block | undefined | null
-
-task('generate-random-numbers', 'Generates random numbers')
-  .addParam('blocks', 'Array of block numbers', undefined, types.json)
-  .addParam('secret', 'Secret number', undefined, types.int)
-  .setAction(async ({ blocks, secret }: { blocks: number[], secret: number }, hre) => {
-    const provider = hre.network.provider
-    const hexSecret = BigNumber.from(secret).toHexString().substring(2)
-    const randomNumbers: BigNumber[] = []
-
-    for (const block of blocks) {
-      const blockHash = await getBlockHash(provider, block)
-      const randomNumberHash = utils.keccak256(blockHash.concat(hexSecret))
-      randomNumbers.push(BigNumber.from(randomNumberHash))
-    }
-
-    randomNumbers.forEach((randomNumber, index) => {
-      console.log(`Random number for block #${blocks[index]}: ${randomNumber}`)
-    })
-  })
-
-async function getBlockHash(provider: EthereumProvider, blockNumber: number) {
-  const hexBlockNumber = BigNumber.from(blockNumber).toHexString()
-  const block: GetBlockNumberResponse = await provider.send('eth_getBlockByNumber', [hexBlockNumber, true])
-  return block.hash
-}

--- a/packages/contracts/scripts/utils/hashTwo.ts
+++ b/packages/contracts/scripts/utils/hashTwo.ts
@@ -1,0 +1,7 @@
+import { BytesLike } from '@ethersproject/bytes'
+import { utils } from 'ethers'
+
+export function hashTwo(first: BytesLike, second: BytesLike): string {
+  const concat = utils.concat([first, second])
+  return utils.keccak256(concat)
+}

--- a/packages/contracts/scripts/utils/types/bytes32.ts
+++ b/packages/contracts/scripts/utils/types/bytes32.ts
@@ -1,6 +1,6 @@
 import { CLIArgumentType } from 'hardhat/src/types'
-import { HardhatError } from 'hardhat/src/internal/core/errors'
-import { ERRORS } from 'hardhat/src/internal/core/errors-list'
+import { HardhatError } from 'hardhat/internal/core/errors'
+import { ERRORS } from 'hardhat/internal/core/errors-list'
 import { utils } from 'ethers'
 
 export const bytes32: CLIArgumentType<Uint8Array> = {
@@ -13,7 +13,7 @@ export const bytes32: CLIArgumentType<Uint8Array> = {
         throw new HardhatError(
           ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
           {
-            strValue,
+            value: strValue,
             name: argName,
             type: bytes32.name,
           },

--- a/packages/contracts/scripts/utils/types/bytes32.ts
+++ b/packages/contracts/scripts/utils/types/bytes32.ts
@@ -1,0 +1,43 @@
+import { CLIArgumentType } from 'hardhat/src/types'
+import { HardhatError } from 'hardhat/src/internal/core/errors'
+import { ERRORS } from 'hardhat/src/internal/core/errors-list'
+import { utils } from 'ethers'
+
+export const bytes32: CLIArgumentType<Uint8Array> = {
+  name: 'bytes32',
+  parse(argName: string, strValue: string): Uint8Array {
+    try {
+      return parseBytes32(strValue)
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new HardhatError(
+          ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+          {
+            strValue,
+            name: argName,
+            type: bytes32.name,
+          },
+          error,
+        )
+      }
+      throw error
+    }
+  },
+
+  validate: (argName: string, value: any): void => {
+    if (value === undefined) {
+      throw new HardhatError(ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
+        value,
+        name: argName,
+        type: bytes32.name,
+      })
+    }
+  },
+}
+
+function parseBytes32(strValue: string): Uint8Array {
+  if (!utils.isHexString(strValue, 32)) {
+    throw new Error('not bytes32')
+  }
+  return utils.arrayify(strValue)
+}

--- a/packages/contracts/scripts/utils/types/index.ts
+++ b/packages/contracts/scripts/utils/types/index.ts
@@ -1,0 +1,2 @@
+export * from './bytes32'
+export * from './intArray'

--- a/packages/contracts/scripts/utils/types/intArray.ts
+++ b/packages/contracts/scripts/utils/types/intArray.ts
@@ -1,0 +1,51 @@
+import { CLIArgumentType } from 'hardhat/src/types'
+import { HardhatError } from 'hardhat/src/internal/core/errors'
+import { ERRORS } from 'hardhat/src/internal/core/errors-list'
+
+export const intArray: CLIArgumentType<any> = {
+  name: 'intArray',
+  parse(argName: string, strValue: string): number[] {
+    try {
+      return parseIntArray(strValue)
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new HardhatError(
+          ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+          {
+            strValue,
+            name: argName,
+            type: intArray.name,
+          },
+          error,
+        )
+      }
+      throw error
+    }
+  },
+
+  validate: (argName: string, value: any): void => {
+    if (value === undefined) {
+      throw new HardhatError(ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
+        value,
+        name: argName,
+        type: intArray.name,
+      })
+    }
+  },
+}
+
+function parseIntArray(strValue: string): number[] {
+  const possiblyIntArray: unknown = JSON.parse(strValue)
+  if (!Array.isArray(possiblyIntArray)) {
+    throw new Error('not an array')
+  }
+
+  return possiblyIntArray.map(parseInt)
+}
+
+function parseInt(possiblyInt: any): number {
+  if (!Number.isInteger(possiblyInt)) {
+    throw new Error('not all elements are integers')
+  }
+  return possiblyInt
+}

--- a/packages/contracts/scripts/utils/types/intArray.ts
+++ b/packages/contracts/scripts/utils/types/intArray.ts
@@ -1,6 +1,6 @@
 import { CLIArgumentType } from 'hardhat/src/types'
-import { HardhatError } from 'hardhat/src/internal/core/errors'
-import { ERRORS } from 'hardhat/src/internal/core/errors-list'
+import { HardhatError } from 'hardhat/internal/core/errors'
+import { ERRORS } from 'hardhat/internal/core/errors-list'
 
 export const intArray: CLIArgumentType<any> = {
   name: 'intArray',
@@ -12,7 +12,7 @@ export const intArray: CLIArgumentType<any> = {
         throw new HardhatError(
           ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
           {
-            strValue,
+            value: strValue,
             name: argName,
             type: intArray.name,
           },

--- a/packages/contracts/test/fixtures/hashingFixture.ts
+++ b/packages/contracts/test/fixtures/hashingFixture.ts
@@ -1,0 +1,6 @@
+import { Wallet } from 'ethers'
+import { Hashing__factory } from 'contracts'
+
+export async function hashingFixture([deployer]: Wallet[]) {
+  return new Hashing__factory(deployer).deploy()
+}

--- a/packages/contracts/test/scripts/utils/hashTwo.test.ts
+++ b/packages/contracts/test/scripts/utils/hashTwo.test.ts
@@ -1,0 +1,22 @@
+import { setupFixtureLoader } from '../../setup'
+import { Hashing } from 'contracts'
+import { hashingFixture } from 'fixtures/hashingFixture'
+import { utils } from 'ethers'
+import { expect } from 'chai'
+import { hashTwo } from 'scripts/utils/hashTwo'
+
+describe('hashTwo', function () {
+  const loadFixture = setupFixtureLoader()
+
+  let hashing: Hashing
+
+  it('concatenates and hashes properly', async function () {
+    hashing = await loadFixture(hashingFixture)
+
+    const first = utils.id('first')
+    const second = utils.id('second')
+    const contractHash = await hashing.hashTwo(first, second)
+
+    expect(hashTwo(first, second)).to.eq(contractHash)
+  })
+})


### PR DESCRIPTION
Example usage and result:
```
bartlomiej@MBP3101-BT0086 contracts % yarn ethereum:generate-random-numbers --blocks '[1512781, 1512782, 1512783, 1512784]' --secret '0xdb8afc34ca10a1b5d68be1957367f36571152b0c28adeda765b2fbad265dcf75'
yarn run v1.22.19
Random number for block #1512781 with hash 0xdb8afc34ca10a1b5d68be1957367f36571152b0c28adeda765b2fbad265dcf75: 0xd34aec1d8f4cea0f346fd76ab76c2084fb4df24f25291fecdfd5c0c2fe40aa4a
Random number for block #1512782 with hash 0x6625c39a2536f919e20fc279b3b59060cd4649b87131b2b0c25f04c84777b7c3: 0x6ab60d3c3c7a2b1917ae4f3180e64e57ec69674d30b77e77a27223f50677bb5a
Random number for block #1512783 with hash 0x27e06340a1ed100829d6ed07489c1437741c7116f49ebbe6051ea8f045d88d83: 0x208d5a0d2002fef544e195898f603e954137155a48b16fbf508b32a5d2cf39d9
Random number for block #1512784 with hash 0xb3b5f815a64910553b7db14a95bce756f3984ef833ff7e591f96d64c4ba74f0b: 0x804d2279532744efa16e18eab60678fcdd5d56afb5a4cda3afc667e6bf0ea3e4

Random numbers as integer array: [95570387342930402721720362284870933581052582798590696159921287358929872923210,48266819462284206066879973842355982524580465425651398833083964479762224102234,14723758101820020229631423878578994532321450357538194266654823749387285379545,58032329772932445563456300714513554503856904998453123358695698106310416311268]
✨  Done in 4.04s.
```

Blocks argument must be string with JSON array, because hardhat tasks don't support arrays.